### PR TITLE
Blogs as Subdomains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@ POSTGRES_PASSWORD="secret"
 DATABASE_URL="postgresql://postgres:secret@db/lists?sslmode=disable"
 LISTS_SSH_PORT=2222
 LISTS_WEB_PORT=3000
+LISTS_DOMAIN="lists.sh"
+LISTS_EMAIL="support@lists.sh"
+CF_API_TOKEN="xxx"

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,8 @@
-lists.sh {
-	tls webmaster@lists.sh
+*.lists.sh, lists.sh {
 	reverse_proxy web:3000
+	tls webmaster@lists.sh
+	tls {
+		dns cloudflare {env.CF_API_TOKEN}
+	}
+	encode zstd gzip
 }

--- a/Dockerfile.caddy
+++ b/Dockerfile.caddy
@@ -1,0 +1,8 @@
+FROM caddy:builder-alpine AS builder
+
+RUN xcaddy build \
+    --with github.com/caddy-dns/cloudflare
+
+FROM caddy:alpine
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ export POSTGRES_PASSWORD="secret"
 export DATABASE_URL="postgresql://postgres:secret@db/lists?sslmode=disable"
 export LISTS_SSH_PORT=2222
 export LISTS_WEB_PORT=3000
+export LISTS_DOMAIN="lists.sh"
+export LISTS_EMAIL="support@lists.sh"
 ```
 
 I just use `direnv` which will load my `.env` file.
@@ -64,6 +66,21 @@ Default port for ssh server is `2222`.
 ```
 
 Default port for web server is `3000`.
+
+### subdomains
+
+Since we use subdomains for blogs, you'll need to update your `/etc/hosts` file
+to accommodate.
+
+```bash
+# /etc/hosts
+127.0.0.1 lists.test
+127.0.0.1 erock.lists.test
+```
+
+Wildcards are not support in `/etc/hosts` so you'll have to add a subdomain for
+each blog in development. For this example you'll also want to change the domain 
+env var to `LISTS_DOMAIN=lists.test`.
 
 ## deployment
 

--- a/html/blog.page.tmpl
+++ b/html/blog.page.tmpl
@@ -6,21 +6,21 @@
 <meta name="description" content="{{if .Header.Bio}}{{.Header.Bio}}{{else}}{{.Header.Title}}{{end}}" />
 
 <meta property="og:type" content="website">
-<meta property="og:site_name" content="lists.sh">
+<meta property="og:site_name" content="{{.Site.Domain}}">
 <meta property="og:url" content="{{.URL}}">
 <meta property="og:title" content="{{.Header.Title}}">
 {{if .Header.Bio}}<meta property="og:description" content="{{.Header.Bio}}">{{end}}
 <meta property="og:image:width" content="300" />
 <meta property="og:image:height" content="300" />
-<meta itemprop="image" content="https://lists.sh/card.png" />
-<meta property="og:image" content="https://lists.sh/card.png" />
+<meta itemprop="image" content="https://{{.Site.Domain}}/card.png" />
+<meta property="og:image" content="https://{{.Site.Domain}}/card.png" />
 
 <meta property="twitter:card" content="summary">
 <meta property="twitter:url" content="{{.URL}}">
 <meta property="twitter:title" content="{{.Header.Title}}">
 {{if .Header.Bio}}<meta property="twitter:description" content="{{.Header.Bio}}">{{end}}
-<meta name="twitter:image" content="https://lists.sh/card.png" />
-<meta name="twitter:image:src" content="https://lists.sh/card.png" />
+<meta name="twitter:image" content="https://{{.Site.Domain}}/card.png" />
+<meta name="twitter:image:src" content="https://{{.Site.Domain}}/card.png" />
 {{end}}
 
 {{define "body"}}
@@ -33,7 +33,7 @@
             <a href="{{.URL}}" class="text-lg">{{.Value}}</a> |
             {{end}}
         {{end}}
-        <a href="{{.Username}}/rss" class="text-lg">rss</a>
+        <a href="{{.RSSURL}}" class="text-lg">rss</a>
     </nav>
     <hr />
 </header>

--- a/html/footer.partial.tmpl
+++ b/html/footer.partial.tmpl
@@ -1,6 +1,6 @@
 {{define "footer"}}
 <footer>
     <hr />
-    published with <a href="/">lists.sh</a>
+    published with <a href={{.Site.HomeURL}}>{{.Site.Domain}}</a>
 </footer>
 {{end}}

--- a/html/help.page.tmpl
+++ b/html/help.page.tmpl
@@ -1,6 +1,6 @@
 {{template "base" .}}
 
-{{define "title"}}help -- lists.sh{{end}}
+{{define "title"}}help -- {{.Site.Domain}}{{end}}
 
 {{define "meta"}}
 <meta name="description" content="questions and answers" />
@@ -27,7 +27,7 @@
     <section id="blog-structure">
         <h2 class="text-xl">What should my blog folder look like?</h2>
         <p>
-            Currently <a href="/">lists.sh</a> only supports a flat folder structure.  Therefore,
+            Currently {{.Site.Domain}} only supports a flat folder structure.  Therefore,
             <code>scp -r</code> is not permitted.  We also only allow <code>.txt</code> files to be
             uploaded.
         </p>
@@ -70,10 +70,10 @@ third-post.txt</pre>
 
         <pre>
 cp /dev/null delete.txt
-scp ./delete.txt lists.sh:/</pre>
+scp ./delete.txt {{.Site.Domain}}:/</pre>
 
         <p>
-            Alternatively, you can go to <code>ssh lists.sh</code> and select "Manage posts."
+            Alternatively, you can go to <code>ssh {{.Site.Domain}}</code> and select "Manage posts."
             Then you can highlight the post you want to delete and then press "X."  It will ask for
             confirmation before actually removing the list.
         </p>
@@ -85,7 +85,7 @@ scp ./delete.txt lists.sh:/</pre>
             Nope!  Just <code>scp</code> the file you want to publish.  For example, if you created
             a new post called <code>taco-tuesday.txt</code> then you would publish it like this:
         </p>
-        <pre>scp ./taco-tuesday.txt lists.sh:</pre>
+        <pre>scp ./taco-tuesday.txt {{.Site.Domain}}:</pre>
     </section>
 
     <section id="blog-header">
@@ -122,7 +122,7 @@ I like to sing. Dance. And I like to have fun fun fun!</pre>
 
     <section id="blog-url">
         <h2 class="text-xl">What is my blog URL?</h2>
-        <pre>https://lists.sh/{username}</pre>
+        <pre>https://{username}.{{.Site.Domain}}</pre>
     </section>
 </main>
 {{template "marketing-footer" .}}

--- a/html/marketing.page.tmpl
+++ b/html/marketing.page.tmpl
@@ -1,32 +1,32 @@
 {{template "base" .}}
 
-{{define "title"}}lists.sh -- a microblog for lists{{end}}
+{{define "title"}}{{.Site.Domain}} -- a microblog for lists{{end}}
 
 {{define "meta"}}
 <meta name="description" content="a microblog for lists" />
 
 <meta property="og:type" content="website">
-<meta property="og:site_name" content="lists.sh">
-<meta property="og:url" content="https://lists.sh">
-<meta property="og:title" content="lists.sh">
+<meta property="og:site_name" content="{{.Site.Domain}}">
+<meta property="og:url" content="https://{{.Site.Domain}}">
+<meta property="og:title" content="{{.Site.Domain}}">
 <meta property="og:description" content="a microblog for lists">
 
 <meta name="twitter:card" content="summary" />
-<meta property="twitter:url" content="https://lists.sh">
-<meta property="twitter:title" content="lists.sh">
+<meta property="twitter:url" content="https://{{.Site.Domain}}">
+<meta property="twitter:title" content="{{.Site.Domain}}">
 <meta property="twitter:description" content="a microblog for lists">
-<meta name="twitter:image" content="https://lists.sh/card.png" />
-<meta name="twitter:image:src" content="https://lists.sh/card.png" />
+<meta name="twitter:image" content="https://{{.Site.Domain}}/card.png" />
+<meta name="twitter:image:src" content="https://{{.Site.Domain}}/card.png" />
 
 <meta property="og:image:width" content="300" />
 <meta property="og:image:height" content="300" />
-<meta itemprop="image" content="https://lists.sh/card.png" />
-<meta property="og:image" content="https://lists.sh/card.png" />
+<meta itemprop="image" content="https://{{.Site.Domain}}/card.png" />
+<meta property="og:image" content="https://{{.Site.Domain}}/card.png" />
 {{end}}
 
 {{define "body"}}
 <header class="text-center">
-    <h1 class="text-2xl font-bold">lists.sh</h1>
+    <h1 class="text-2xl font-bold">{{.Site.Domain}}</h1>
     <p class="text-lg">A microblog for lists</p>
     <p class="text-lg"><a href="/read">discover</a> some interesting lists</p>
     <hr />
@@ -36,8 +36,8 @@
     <section>
         <h2 class="text-lg font-bold">Examples</h2>
         <p>
-            <a href="/erock">blog</a> |
-            <a href="/erock/knowledge-management-apps">list</a> |
+            <a href="//erock.{{.Site.Domain}}">blog</a> |
+            <a href="//erock.{{.Site.Domain}}/knowledge-management-apps">list</a> |
             <a href="https://github.com/neurosnap/lists-blog">blog source</a>
         </p>
     </section>
@@ -46,7 +46,7 @@
         <h2 class="text-lg font-bold">Create your account with Public-Key Cryptography</h2>
         <p>We don't want your email address.</p>
         <p>To get started, simply ssh into our content management system:</p>
-        <pre>ssh lists.sh</pre>
+        <pre>ssh {{.Site.Domain}}</pre>
         <div class="text-sm font-italic note">note: Ed25519 signing algorithm is recommended.</div>
         <p>After that, just set a username and you're ready to start writing!</p>
     </section>
@@ -70,7 +70,7 @@ Saturday</pre>
             When your post is ready to be published, copy the file to our server with a familiar
             command:
         </p>
-        <pre>scp ~/blog/*.txt lists.sh:/</pre>
+        <pre>scp ~/blog/*.txt {{.Site.Domain}}:/</pre>
         <div class="text-sm font-italic note">note: if using openssh v9+, also supply the `-O` flag.</div>
         <p>We'll either create or update the lists for you.</p>
     </section>

--- a/html/ops.page.tmpl
+++ b/html/ops.page.tmpl
@@ -1,9 +1,9 @@
 {{template "base" .}}
 
-{{define "title"}}operations -- lists.sh{{end}}
+{{define "title"}}operations -- {{.Site.Domain}}{{end}}
 
 {{define "meta"}}
-<meta name="description" content="lists.sh operations" />
+<meta name="description" content="{{.Site.Domain}} operations" />
 {{end}}
 
 {{define "body"}}
@@ -18,7 +18,7 @@
     <section>
         <h2 class="text-xl">Purpose</h2>
         <p>
-            lists.sh exists to allow people to create and share their lists
+            {{.Site.Domain}} exists to allow people to create and share their lists
             without the need to set up their own server or be part of a platform
             that shows ads or tracks its users.
         </p>
@@ -35,7 +35,7 @@
     <section>
         <h2 class="text-xl">Code of Content Publication</h2>
         <p>
-            Content in lists.sh blogs is unfiltered and unmonitored. Users are free to publish any
+            Content in {{.Site.Domain}} blogs is unfiltered and unmonitored. Users are free to publish any
             combination of words and pixels except for: content of animosity or disparagement of an
             individual or a group on account of a group characteristic such as race, color, national
             origin, sex, disability, religion, or sexual orientation, which will be taken down
@@ -43,7 +43,7 @@
         </p>
         <p>
             If one notices something along those lines in a blog please let us know at
-            <a href="mailto:support@lists.sh">support@lists.sh</a>.
+            <a href="mailto:{{.Site.Email}}">{{.Site.Email}}</a>.
         </p>
     </section>
     <section>
@@ -73,25 +73,25 @@
     <section>
         <h2 class="text-xl">Service Availability</h2>
         <p>
-         We provide the lists.sh service on an "as is" and "as available" basis. We do not offer
+         We provide the {{.Site.Domain}} service on an "as is" and "as available" basis. We do not offer
          service-level agreements but do take uptime seriously.
         </p>
     </section>
     <section>
         <h2 class="text-xl">Contact and Support</h2>
         <p>
-            Email us at <a href="mailto:support@lists.sh">support@lists.sh</a>
+            Email us at <a href="mailto:support@{{.Site.Domain}}">support@{{.Site.Domain}}</a>
             with any questions.
         </p>
     </section>
     <section>
         <h2 class="text-xl">Acknowledgments</h2>
         <p>
-            lists.sh was inspired by <a href="https://mataroa.blog">Mataroa Blog</a>
+            {{.Site.Domain}} was inspired by <a href="https://mataroa.blog">Mataroa Blog</a>
             and <a href="https://bearblog.dev/">Bear Blog</a>.
         </p>
         <p>
-            lists.sh is built with many open source technologies.
+            {{.Site.Domain}} is built with many open source technologies.
         </p>
         <p>
             In particular we would like to thank:

--- a/html/post.page.tmpl
+++ b/html/post.page.tmpl
@@ -6,21 +6,21 @@
 <meta name="description" content="{{.Description}}" />
 
 <meta property="og:type" content="website">
-<meta property="og:site_name" content="lists.sh">
+<meta property="og:site_name" content="{{.Site.Domain}}">
 <meta property="og:url" content="{{.URL}}">
 <meta property="og:title" content="{{.Title}}">
 {{if .Description}}<meta property="og:description" content="{{.Description}}">{{end}}
 <meta property="og:image:width" content="300" />
 <meta property="og:image:height" content="300" />
-<meta itemprop="image" content="https://lists.sh/card.png" />
-<meta property="og:image" content="https://lists.sh/card.png" />
+<meta itemprop="image" content="https://{{.Site.Domain}}/card.png" />
+<meta property="og:image" content="https://{{.Site.Domain}}/card.png" />
 
 <meta property="twitter:card" content="summary">
 <meta property="twitter:url" content="{{.URL}}">
 <meta property="twitter:title" content="{{.Title}}">
 {{if .Description}}<meta property="twitter:description" content="{{.Description}}">{{end}}
-<meta name="twitter:image" content="https://lists.sh/card.png" />
-<meta name="twitter:image:src" content="https://lists.sh/card.png" />
+<meta name="twitter:image" content="https://{{.Site.Domain}}/card.png" />
+<meta name="twitter:image:src" content="https://{{.Site.Domain}}/card.png" />
 {{end}}
 
 {{define "body"}}
@@ -29,7 +29,7 @@
     <p class="font-bold m-0">
         <time datetime="{{.PublishAtISO}}">{{.PublishAt}}</time>
         <span> on </span>
-        <a href="/{{.Username}}">{{.BlogName}}</a></p>
+        <a href="{{.BlogURL}}">{{.BlogName}}</a></p>
     {{if .Description}}<div class="my font-italic">{{.Description}}</div>{{end}}
 </header>
 <main>

--- a/html/privacy.page.tmpl
+++ b/html/privacy.page.tmpl
@@ -1,9 +1,9 @@
 {{template "base" .}}
 
-{{define "title"}}privacy -- lists.sh{{end}}
+{{define "title"}}privacy -- {{.Site.Domain}}{{end}}
 
 {{define "meta"}}
-<meta name="description" content="lists.sh privacy policy" />
+<meta name="description" content="{{.Site.Domain}} privacy policy" />
 {{end}}
 
 {{define "body"}}
@@ -15,7 +15,7 @@
     <section>
         <h2 class="text-xl">Account Data</h2>
         <p>
-            In order to have a functional account at lists.sh, we need to store
+            In order to have a functional account at {{.Site.Domain}}, we need to store
             your public key.  That is the only piece of information we record for a user.
         </p>
         <p>

--- a/html/read.page.tmpl
+++ b/html/read.page.tmpl
@@ -1,6 +1,6 @@
 {{template "base" .}}
 
-{{define "title"}}discover lists -- lists.sh{{end}}
+{{define "title"}}discover lists -- {{.Site.Domain}}{{end}}
 
 {{define "meta"}}
 <meta name="description" content="discover interesting lists" />

--- a/html/spec.page.tmpl
+++ b/html/spec.page.tmpl
@@ -1,6 +1,6 @@
 {{template "base" .}}
 
-{{define "title"}}specification -- lists.sh{{end}}
+{{define "title"}}specification -- {{.Site.Domain}}{{end}}
 
 {{define "meta"}}
 <meta name="description" content="a specification for lists" />
@@ -36,7 +36,7 @@
 
         <p>
             Feedback on any part of this is extremely welcome, please email
-            <a href="mailto:support@lists.sh">support@lists.sh</a>.
+            <a href="mailto:{{.Site.Email}}">{{.Site.Email}}</a>.
         </p>
 
         <p>
@@ -71,7 +71,7 @@
     <section id="file-extensions">
         <h2 class="text-xl">File extension</h2>
         <p>
-            <a href="/">lists.sh</a> only supports the <code>.txt</code> file extension and will
+            {{.Site.Domain}} only supports the <code>.txt</code> file extension and will
             ignore all other file extensions.
         </p>
     </section>
@@ -95,9 +95,9 @@
             Hyperlinks are denoted by the prefix <code>=></code>.  The following text should then be
             the hyperlink.
         </p>
-        <pre>=> https://lists.sh</pre>
+        <pre>=> https://{{.Site.Domain}}</pre>
         <p>Optionally you can supply the hyperlink text immediately following the link.</p>
-        <pre>=> https://lists.sh microblog for lists</pre>
+        <pre>=> https://{{.Site.Domain}} microblog for lists</pre>
     </section>
 
     <section id="images">

--- a/html/transparency.page.tmpl
+++ b/html/transparency.page.tmpl
@@ -1,9 +1,9 @@
 {{template "base" .}}
 
-{{define "title"}}transparency -- lists.sh{{end}}
+{{define "title"}}transparency -- {{.Site.Domain}}{{end}}
 
 {{define "meta"}}
-<meta name="description" content="full transparency of analytics and cost at lists.sh" />
+<meta name="description" content="full transparency of analytics and cost at {{.Site.Domain}}" />
 {{end}}
 
 {{define "body"}}
@@ -20,27 +20,27 @@
 
         <article>
             <h2 class="text-lg">Total users</h2>
-            <div>{{.TotalUsers}}</div>
+            <div>{{.Analytics.TotalUsers}}</div>
         </article>
 
         <article>
             <h2 class="text-lg">New users in the last month</h2>
-            <div>{{.UsersLastMonth}}</div>
+            <div>{{.Analytics.UsersLastMonth}}</div>
         </article>
 
         <article>
             <h2 class="text-lg">Total posts</h2>
-            <div>{{.TotalPosts}}</div>
+            <div>{{.Analytics.TotalPosts}}</div>
         </article>
 
         <article>
             <h2 class="text-lg">New posts in the last month</h2>
-            <div>{{.PostsLastMonth}}</div>
+            <div>{{.Analytics.PostsLastMonth}}</div>
         </article>
 
         <article>
             <h2 class="text-lg">Users with at least one post</h2>
-            <div>{{.UsersWithPost}}</div>
+            <div>{{.Analytics.UsersWithPost}}</div>
         </article>
     </section>
 

--- a/internal/cms/ui.go
+++ b/internal/cms/ui.go
@@ -331,7 +331,7 @@ func (m model) quitView() string {
 	if m.err != nil {
 		return fmt.Sprintf("Uh oh, there’s been an error: %s\n", m.err)
 	}
-	return "Thanks for using lists.sh!\n"
+	return "Thanks for using lists!\n"
 }
 
 func footerView(m model) string {

--- a/internal/main.go
+++ b/internal/main.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"encoding/base64"
 	"fmt"
+	"html/template"
 	"log"
 	"math"
 	"os"
@@ -17,6 +18,32 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
 )
+
+type SitePageData struct {
+	Domain  template.URL
+	HomeURL template.URL
+	Email   string
+}
+
+var Domain = GetEnv("LISTS_DOMAIN", "lists.sh")
+var Email = GetEnv("LISTS_EMAIL", "support@lists.sh")
+var SiteData = SitePageData{
+	Domain:  template.URL(Domain),
+	HomeURL: template.URL(HomeURL()),
+	Email:   Email,
+}
+
+func BlogURL(username string) string {
+	return fmt.Sprintf("//%s.%s", username, Domain)
+}
+
+func RssBlogURL(username string) string {
+	return fmt.Sprintf("//%s.%s/rss", username, Domain)
+}
+
+func HomeURL() string {
+	return fmt.Sprintf("//%s", Domain)
+}
 
 func CreateLogger() *zap.SugaredLogger {
 	logger, err := zap.NewProduction()

--- a/internal/scp/scp.go
+++ b/internal/scp/scp.go
@@ -38,7 +38,7 @@ func Middleware(wh CopyFromClientHandler, dbpool db.DB) wish.Middleware {
 			}
 
 			if info.Recursive {
-				err := fmt.Errorf("recursive not supported. try `scp ./blog/*.txt lists.sh` instead")
+				err := fmt.Errorf("recursive not supported. try `scp ./blog/*.txt %s` instead", internal.Domain)
 				errHandler(s, err)
 				return
 			}

--- a/internal/ui/account/create.go
+++ b/internal/ui/account/create.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	input "github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/neurosnap/lists.sh/internal"
 	"github.com/neurosnap/lists.sh/internal/db"
 	"github.com/neurosnap/lists.sh/internal/ui/common"
 )
@@ -242,7 +243,7 @@ func View(m CreateModel) string {
 	s += "Then create a folder locally (e.g. ~/blog).\n"
 	s += "Then write your lists in plain text files (e.g. hello-world.txt).\n"
 	s += "Finally, send your list files to us:\n\n"
-	s += "scp ~/blog/*.txt lists.sh:/\n\n"
+	s += fmt.Sprintf("scp ~/blog/*.txt %s:/\n\n", internal.Domain)
 	s += "Enter a username\n\n"
 	s += m.input.View() + "\n\n"
 

--- a/internal/ui/common/styles.go
+++ b/internal/ui/common/styles.go
@@ -1,6 +1,9 @@
 package common
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"github.com/charmbracelet/lipgloss"
+	"github.com/neurosnap/lists.sh/internal"
+)
 
 // Color definitions.
 var (
@@ -81,7 +84,7 @@ func DefaultStyles() Styles {
 		Foreground(cream).
 		Background(lipgloss.Color("#5A56E0")).
 		Padding(0, 1).
-		SetString("lists.sh")
+		SetString(internal.Domain)
 	s.App = lipgloss.NewStyle().Margin(1, 0, 1, 2)
 
 	return s

--- a/internal/ui/info/info.go
+++ b/internal/ui/info/info.go
@@ -1,11 +1,8 @@
 package info
 
-// Fetch a user's basic Charm account info
-
 import (
-	"fmt"
-
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/neurosnap/lists.sh/internal"
 	"github.com/neurosnap/lists.sh/internal/db"
 	"github.com/neurosnap/lists.sh/internal/ui/common"
 )
@@ -76,7 +73,7 @@ func (m Model) bioView() string {
 	}
 	return common.KeyValueView(
 		"Username", username,
-		"Blog URL", fmt.Sprintf("https://lists.sh/%s", username),
+		"Blog URL", internal.BlogURL(username),
 		"Public key", m.User.PublicKey.Key,
 		"Joined", m.User.CreatedAt.Format("02 Jan 2006"),
 	)

--- a/internal/ui/posts/posts.go
+++ b/internal/ui/posts/posts.go
@@ -232,7 +232,7 @@ func (m Model) View() string {
 	case stateLoading:
 		s = m.spinner.View() + " Loading...\n\n"
 	case stateQuitting:
-		s = "Thanks for using lists.sh!\n"
+		s = "Thanks for using lists!\n"
 	default:
 		s = "Here are the posts linked to your account.\n\n"
 

--- a/production.yml
+++ b/production.yml
@@ -2,8 +2,10 @@ version: "3.7"
 
 services:
   caddy:
-    image: caddy:alpine
+    image: neurosnap/lists-caddy
     restart: unless-stopped
+    env_file:
+      - .env.prod
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - caddy_data:/data


### PR DESCRIPTION
The goal of this PR is to add subdomain support for lists.sh.  Another goal was to abstract away the `lists.sh` name so people can self-host a little easier.

There is definitely more work to do here to better support self-hosting but this is a good start.

Closes #22.